### PR TITLE
Svedit V3: Make Blocks Editable via Markdown Editor

### DIFF
--- a/svedit/package.json
+++ b/svedit/package.json
@@ -29,7 +29,9 @@
 	"dependencies": {
 		"@markdoc/markdoc": "^0.4.0",
 		"add": "^2.0.6",
+		"js-yaml": "^4.1.0",
 		"lucide-svelte": "^0.468.0",
+		"marked": "^15.0.4",
 		"pnpm": "^9.15.0",
 		"postcss": "^8.4.49"
 	}

--- a/svedit/package.json
+++ b/svedit/package.json
@@ -27,6 +27,7 @@
 		"vite": "^6.0.0"
 	},
 	"dependencies": {
+		"@markdoc/markdoc": "^0.4.0",
 		"add": "^2.0.6",
 		"lucide-svelte": "^0.468.0",
 		"pnpm": "^9.15.0",

--- a/svedit/pnpm-lock.yaml
+++ b/svedit/pnpm-lock.yaml
@@ -14,9 +14,15 @@ importers:
       add:
         specifier: ^2.0.6
         version: 2.0.6
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.0
       lucide-svelte:
         specifier: ^0.468.0
         version: 0.468.0(svelte@5.11.2)
+      marked:
+        specifier: ^15.0.4
+        version: 15.0.4
       pnpm:
         specifier: ^9.15.0
         version: 9.15.0
@@ -467,6 +473,9 @@ packages:
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
@@ -698,6 +707,10 @@ packages:
     resolution: {integrity: sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==}
     hasBin: true
 
+  js-yaml@4.1.0:
+    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+    hasBin: true
+
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
@@ -722,6 +735,11 @@ packages:
 
   magic-string@0.30.15:
     resolution: {integrity: sha512-zXeaYRgZ6ldS1RJJUrMrYgNJ4fdwnyI6tVqoiIhyCyv5IVTK9BU8Ic2l253GGETQHxI4HNUwhJ3fjDhKqEoaAw==}
+
+  marked@15.0.4:
+    resolution: {integrity: sha512-TCHvDqmb3ZJ4PWG7VEGVgtefA5/euFmsIhxtD0XsBxI39gUSKL81mIRFdt0AiNQozUahd4ke98ZdirExd/vSEw==}
+    engines: {node: '>= 18'}
+    hasBin: true
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -1378,6 +1396,8 @@ snapshots:
 
   arg@5.0.2: {}
 
+  argparse@2.0.1: {}
+
   aria-query@5.3.2: {}
 
   autoprefixer@10.4.20(postcss@8.4.49):
@@ -1608,6 +1628,10 @@ snapshots:
 
   jiti@1.21.6: {}
 
+  js-yaml@4.1.0:
+    dependencies:
+      argparse: 2.0.1
+
   kleur@4.1.5: {}
 
   lilconfig@3.1.3: {}
@@ -1625,6 +1649,8 @@ snapshots:
   magic-string@0.30.15:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  marked@15.0.4: {}
 
   merge2@1.4.1: {}
 

--- a/svedit/pnpm-lock.yaml
+++ b/svedit/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@markdoc/markdoc':
+        specifier: ^0.4.0
+        version: 0.4.0
       add:
         specifier: ^2.0.6
         version: 2.0.6
@@ -252,6 +255,18 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
+  '@markdoc/markdoc@0.4.0':
+    resolution: {integrity: sha512-fSh4P3Y4E7oaKYc2oNzSIJVPDto7SMzAuQN1Iyx53UxzleA6QzRdNWRxmiPqtVDaDi5dELd2yICoG91csrGrAw==}
+    engines: {node: '>=14.7.0'}
+    peerDependencies:
+      '@types/react': '*'
+      react: '*'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -403,6 +418,15 @@ packages:
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
+
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it@12.2.3':
+    resolution: {integrity: sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
   acorn-typescript@1.4.13:
     resolution: {integrity: sha512-xsc9Xv0xlVfwp2o7sQ+GCQ1PgbkdcpWdTzrwXxO3xDMTAywVS3oXVOcOHuRjAPkS4P9b+yc/qNF15460v+jp4Q==}
@@ -1184,6 +1208,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  '@markdoc/markdoc@0.4.0':
+    optionalDependencies:
+      '@types/markdown-it': 12.2.3
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -1310,6 +1338,18 @@ snapshots:
   '@types/cookie@0.6.0': {}
 
   '@types/estree@1.0.6': {}
+
+  '@types/linkify-it@5.0.0':
+    optional: true
+
+  '@types/markdown-it@12.2.3':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+    optional: true
+
+  '@types/mdurl@2.0.0':
+    optional: true
 
   acorn-typescript@1.4.13(acorn@8.14.0):
     dependencies:

--- a/svedit/src/app.css
+++ b/svedit/src/app.css
@@ -4,19 +4,28 @@
 
 /* Typography Styles */
 h1 {
-  @apply scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl;
+  @apply scroll-m-20 text-3xl font-extrabold tracking-tight lg:text-5xl;
 }
 h2 {
-  @apply scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight transition-colors first:mt-0;
+  @apply scroll-m-20 text-2xl font-bold tracking-tight transition-colors mt-0;
 }
 h3 {
-  @apply scroll-m-20 text-2xl font-semibold tracking-tight;
-}
-h4 {
   @apply scroll-m-20 text-xl font-semibold tracking-tight;
 }
+h4 {
+  @apply scroll-m-20 text-lg font-semibold tracking-tight;
+}
 p {
-  @apply leading-7 [&:not(:first-child)]:mt-6;
+  @apply leading-4 [&:not(:first-child)]:mt-1;
+}
+a {
+  @apply text-cyan-800 underline;
+}
+ul {
+  @apply list-disc pl-6;
+}
+ol {
+  @apply list-decimal pl-6;
 }
 blockquote {
   @apply mt-6 border-l-2 pl-6 italic;
@@ -90,17 +99,17 @@ code {
 
 @layer base {
   @font-face {
-    font-family: 'geist-sans';
+    font-family: "geist-sans";
     src: url("/fonts/Geist/geist.woff2") format("woff2");
     font-display: swap;
-  }  
+  }
   * {
     @apply border-border;
   }
   body {
     @apply bg-background text-foreground;
     font-synthesis-weight: none;
-    text-rendering: optimizeLegibility;      
+    text-rendering: optimizeLegibility;
   }
   .antialiased {
     -webkit-font-smoothing: antialiased;

--- a/svedit/src/lib/components/ui/label/index.ts
+++ b/svedit/src/lib/components/ui/label/index.ts
@@ -1,0 +1,7 @@
+import Root from "./label.svelte";
+
+export {
+	Root,
+	//
+	Root as Label,
+};

--- a/svedit/src/lib/components/ui/label/label.svelte
+++ b/svedit/src/lib/components/ui/label/label.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { Label as LabelPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: LabelPrimitive.RootProps = $props();
+</script>
+
+<LabelPrimitive.Root
+	bind:ref
+	class={cn(
+		"text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+		className
+	)}
+	{...restProps}
+/>

--- a/svedit/src/lib/components/ui/scroll-area/index.ts
+++ b/svedit/src/lib/components/ui/scroll-area/index.ts
@@ -1,0 +1,10 @@
+import Scrollbar from "./scroll-area-scrollbar.svelte";
+import Root from "./scroll-area.svelte";
+
+export {
+	Root,
+	Scrollbar,
+	//,
+	Root as ScrollArea,
+	Scrollbar as ScrollAreaScrollbar,
+};

--- a/svedit/src/lib/components/ui/scroll-area/scroll-area-scrollbar.svelte
+++ b/svedit/src/lib/components/ui/scroll-area/scroll-area-scrollbar.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import { ScrollArea as ScrollAreaPrimitive, type WithoutChild } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		orientation = "vertical",
+		children,
+		...restProps
+	}: WithoutChild<ScrollAreaPrimitive.ScrollbarProps> = $props();
+</script>
+
+<ScrollAreaPrimitive.Scrollbar
+	bind:ref
+	{orientation}
+	class={cn(
+		"flex touch-none select-none transition-colors",
+		orientation === "vertical" && "h-full w-2.5 border-l border-l-transparent p-px",
+		orientation === "horizontal" && "h-2.5 w-full border-t border-t-transparent p-px",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+	<ScrollAreaPrimitive.Thumb
+		class={cn("bg-border relative rounded-full", orientation === "vertical" && "flex-1")}
+	/>
+</ScrollAreaPrimitive.Scrollbar>

--- a/svedit/src/lib/components/ui/scroll-area/scroll-area.svelte
+++ b/svedit/src/lib/components/ui/scroll-area/scroll-area.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import { ScrollArea as ScrollAreaPrimitive, type WithoutChild } from "bits-ui";
+	import { Scrollbar } from "./index.js";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		orientation = "vertical",
+		scrollbarXClasses = "",
+		scrollbarYClasses = "",
+		children,
+		...restProps
+	}: WithoutChild<ScrollAreaPrimitive.RootProps> & {
+		orientation?: "vertical" | "horizontal" | "both" | undefined;
+		scrollbarXClasses?: string | undefined;
+		scrollbarYClasses?: string | undefined;
+	} = $props();
+</script>
+
+<ScrollAreaPrimitive.Root bind:ref {...restProps} class={cn("relative overflow-hidden", className)}>
+	<ScrollAreaPrimitive.Viewport class="h-full w-full rounded-[inherit]">
+		{@render children?.()}
+	</ScrollAreaPrimitive.Viewport>
+	{#if orientation === "vertical" || orientation === "both"}
+		<Scrollbar orientation="vertical" class={scrollbarYClasses} />
+	{/if}
+	{#if orientation === "horizontal" || orientation === "both"}
+		<Scrollbar orientation="horizontal" class={scrollbarXClasses} />
+	{/if}
+	<ScrollAreaPrimitive.Corner />
+</ScrollAreaPrimitive.Root>

--- a/svedit/src/lib/components/ui/separator/index.ts
+++ b/svedit/src/lib/components/ui/separator/index.ts
@@ -1,0 +1,7 @@
+import Root from "./separator.svelte";
+
+export {
+	Root,
+	//
+	Root as Separator,
+};

--- a/svedit/src/lib/components/ui/separator/separator.svelte
+++ b/svedit/src/lib/components/ui/separator/separator.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import { Separator as SeparatorPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		orientation = "horizontal",
+		...restProps
+	}: SeparatorPrimitive.RootProps = $props();
+</script>
+
+<SeparatorPrimitive.Root
+	bind:ref
+	class={cn(
+		"bg-border shrink-0",
+		orientation === "horizontal" ? "h-[1px] w-full" : "min-h-full w-[1px]",
+		className
+	)}
+	{orientation}
+	{...restProps}
+/>

--- a/svedit/src/lib/components/ui/textarea/index.ts
+++ b/svedit/src/lib/components/ui/textarea/index.ts
@@ -1,0 +1,28 @@
+import Root from "./textarea.svelte";
+
+type FormTextareaEvent<T extends Event = Event> = T & {
+	currentTarget: EventTarget & HTMLTextAreaElement;
+};
+
+type TextareaEvents = {
+	blur: FormTextareaEvent<FocusEvent>;
+	change: FormTextareaEvent<Event>;
+	click: FormTextareaEvent<MouseEvent>;
+	focus: FormTextareaEvent<FocusEvent>;
+	keydown: FormTextareaEvent<KeyboardEvent>;
+	keypress: FormTextareaEvent<KeyboardEvent>;
+	keyup: FormTextareaEvent<KeyboardEvent>;
+	mouseover: FormTextareaEvent<MouseEvent>;
+	mouseenter: FormTextareaEvent<MouseEvent>;
+	mouseleave: FormTextareaEvent<MouseEvent>;
+	paste: FormTextareaEvent<ClipboardEvent>;
+	input: FormTextareaEvent<InputEvent>;
+};
+
+export {
+	Root,
+	//
+	Root as Textarea,
+	type TextareaEvents,
+	type FormTextareaEvent,
+};

--- a/svedit/src/lib/components/ui/textarea/textarea.svelte
+++ b/svedit/src/lib/components/ui/textarea/textarea.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import type { WithElementRef, WithoutChildren } from "bits-ui";
+	import type { HTMLTextareaAttributes } from "svelte/elements";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		value = $bindable(),
+		class: className,
+		...restProps
+	}: WithoutChildren<WithElementRef<HTMLTextareaAttributes>> = $props();
+</script>
+
+<textarea
+	bind:this={ref}
+	bind:value
+	class={cn(
+		"border-input placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-[60px] w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-sm focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+		className
+	)}
+	{...restProps}
+></textarea>

--- a/svedit/src/lib/markdoc/Callout.svelte
+++ b/svedit/src/lib/markdoc/Callout.svelte
@@ -1,0 +1,24 @@
+<script>
+  /** @type {"check"} */
+  export let type;
+
+  if (type != "check") console.warn("Callout.svelte only supports type: check");
+</script>
+
+<div class="callout {type}">
+  <slot></slot>
+</div>
+
+<style>
+  .callout {
+    display: inline-flex;
+    line-height: 20px;
+    padding: 12px 20px;
+    border: 1px solid #dce6e9;
+    border-radius: 4px;
+  }
+
+  .check {
+    background-color: #f6f9fc;
+  }
+</style>

--- a/svedit/src/lib/markdoc/Markdoc.svelte
+++ b/svedit/src/lib/markdoc/Markdoc.svelte
@@ -1,0 +1,15 @@
+<script>
+  export let doc = "";
+  export let config = {};
+  export let components = new Map();
+
+  import Markdoc from "@markdoc/markdoc";
+  import Tags from "$lib/markdoc/Tags.svelte";
+  import { add_frontmatter } from "$lib/markdoc/frontmatter.js";
+
+  const ast = Markdoc.parse(doc);
+  const config_with_frontmatter = add_frontmatter(ast, config);
+  const content = Markdoc.transform(ast, config_with_frontmatter);
+</script>
+
+<Tags children={content.children} {components}></Tags>

--- a/svedit/src/lib/markdoc/Tags.svelte
+++ b/svedit/src/lib/markdoc/Tags.svelte
@@ -1,0 +1,20 @@
+<!-- adapted from https://github.com/movingbrands/svelte-portable-text -->
+<script>
+  export let children = [];
+  export let components = new Map();
+</script>
+
+{#each children as child}
+  {#if typeof child === "string"}{child}{/if}
+  {#if child.children}
+    {#if components.has(child.name)}
+      <svelte:component this={components.get(child.name)} {...child.attributes}>
+        <svelte:self children={child.children} />
+      </svelte:component>
+    {:else}
+      <svelte:element this={child.name} {...child.attributes}>
+        <svelte:self children={child.children} />
+      </svelte:element>
+    {/if}
+  {/if}
+{/each}

--- a/svedit/src/lib/markdoc/frontmatter.js
+++ b/svedit/src/lib/markdoc/frontmatter.js
@@ -1,0 +1,8 @@
+import yaml from "js-yaml";
+
+export function add_frontmatter(ast, config) {
+  const frontmatter = ast.attributes.frontmatter ? yaml.load(ast.attributes.frontmatter) : {};
+  const markdoc = Object.assign(config?.variables?.markdoc || {}, { frontmatter });
+  const variables = Object.assign(config?.variables || {}, { markdoc });
+	return Object.assign(config, { variables });
+}

--- a/svedit/src/lib/svedit/MarkdocBlock.svelte
+++ b/svedit/src/lib/svedit/MarkdocBlock.svelte
@@ -1,0 +1,53 @@
+<script>
+  // a single Markdoc component
+  import Markdoc from "$lib/markdoc/Markdoc.svelte";
+
+  // the doc itself (lifted from https://markdoc.io/sandbox?mode=preview)
+  const doc = `---
+title: What is Markdoc?
+---
+
+# {% $markdoc.frontmatter.title %} {% #overview %}
+
+Markdoc is a Markdown-based syntax and toolchain for creating custom documentation sites. Stripe created Markdoc to power [our public docs](http://stripe.com/docs).
+
+{% callout type="check" %}
+Markdoc is open-source—check out its [source](http://github.com/markdoc/markdoc) to see how it works.
+{% /callout %}
+
+## How is Markdoc different?
+Markdoc uses a fully declarative approach to composition and flow control, where other solutions… [Read more](/docs/overview).
+
+## Next steps
+- [Install Markdoc](/docs/getting-started)
+- [Explore the syntax](/docs/syntax)
+`;
+
+  // markdoc config
+  const config = {
+    tags: {
+      callout: {
+        render: "Callout",
+        description: "Display the enclosed content in a callout box",
+        children: ["paragraph", "tag", "list"],
+        attributes: {
+          type: {
+            type: String,
+            default: "note",
+            matches: ["check", "error", "note", "warning"],
+          },
+        },
+      },
+    },
+  };
+
+  // any custom components (tags) that you want to pass in
+  import Callout from "$lib/markdoc/Callout.svelte";
+  const components = new Map([["Callout", Callout]]);
+</script>
+
+<div class="w-full p-4 bg-amber-100 flex flex-col gap-2">
+  <Markdoc {doc} {config} {components} />
+  <!-- {html.replace(/<p>/g, "<span>").replace(/<\/p>/g, "\n</span>")}
+  {@html html.replace(/<p/g, "<span").replace(/<\/p>/g, "\n</span>")} -->
+</div>

--- a/svedit/src/lib/svedit/MarkdownBlock.svelte
+++ b/svedit/src/lib/svedit/MarkdownBlock.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  // Import markdown conversion library
+  import { marked } from "marked";
+  import type BlockData from "$lib/svedit/BlockData.svelte";
+  import { Textarea } from "$lib/components/ui/textarea/index";
+  import { ScrollArea } from "$lib/components/ui/scroll-area/index";
+  import { Label } from "$lib/components/ui/label/index";
+  import Separator from "$lib/components/ui/separator/separator.svelte";
+
+  interface Props {
+    block: BlockData;
+  }
+  let { block }: Props = $props();
+</script>
+
+{#if block.markdown_setting === "both"}
+  <div class="flex flex-row py-0" contenteditable="true">
+    <div class="flex flex-col gap-1 min-h-max w-1/2 px-4">
+      <!-- Declare a textarea where the user can enter markdown, and bind it to the variable `markdown` -->
+      <Label for="markdown" class="font-bold">Markdown Editor</Label>
+      <Textarea
+        id="markdown"
+        class="w-full min-h-40 text-xs bg-white bg-opacity-100"
+        bind:value={block.markdown}
+        placeholder="Add some markdown!"
+      ></Textarea>
+    </div>
+    <Separator orientation="vertical" class="w-[2px]" />
+
+    <!-- Convert the markdown to HTML and display it -->
+    <div
+      class="w-1/2 min-h-max flex flex-col px-2 gap-2"
+      contenteditable="false"
+    >
+      <Label for="preview" class="font-bold">Preview</Label>
+      <ScrollArea
+        id="preview"
+        class="rounded-md border p-4 text-sm bg-white bg-opacity-100"
+        orientation="both"
+      >
+        {@html block.renderedMarkdown}
+      </ScrollArea>
+    </div>
+  </div>
+{:else if block.markdown_setting === "preview"}
+  <div class="p-0 w-full flex flex-col gap-2">
+    {@html block.renderedMarkdown}
+  </div>
+{/if}
+
+<!-- Make it look (slightly) nicer ;) -->
+<style>
+  :global(body) {
+    padding: 0;
+  }
+</style>

--- a/svedit/src/lib/svedit/Svedit.svelte
+++ b/svedit/src/lib/svedit/Svedit.svelte
@@ -26,7 +26,8 @@
 </script>
 
 <div class="svedit">
-  <div class="svedit-canvas {css_class}" bind:this={ref} {onbeforeinput}>
+  <!-- <div class="svedit-canvas {css_class}" bind:this={ref} {onbeforeinput}> -->
+  <div class="svedit-canvas {css_class}">
     <Block block={sveditSession.rootBlock} />
   </div>
 </div>

--- a/svedit/src/lib/svedit/types.ts
+++ b/svedit/src/lib/svedit/types.ts
@@ -54,7 +54,8 @@ export type Fragment = {
  * Block Types
  ***********************************************/
 
-export type BlockType = 'text' | 'page' | 'story' | 'list' | 'unknown';
+export type BlockType = 'text' | 'page' | 'story' | 'list' | 'unknown' | 'markdown';
+export type MarkdownSetting = "both" | "preview";
 export type FlowType = 'inline' | 'distinct' | 'card';
 export type ImageLayoutType = 'left' | 'right' | 'top' | 'bottom';
 

--- a/svedit/src/routes/editor/+page.svelte
+++ b/svedit/src/routes/editor/+page.svelte
@@ -1,54 +1,38 @@
 <script lang="ts">
   import { PreAnnText } from "$lib/svedit/types";
   import BlockData from "$lib/svedit/BlockData.svelte";
+  import MarkdocBlock from "$lib/svedit/MarkdocBlock.svelte";
   import Svedit from "$lib/svedit/Svedit.svelte";
   import SveditSession from "$lib/svedit/SveditSession.svelte";
+  import Separator from "$lib/components/ui/separator/separator.svelte";
 
   let rootBlock = $state(
     new BlockData({
       type: "list",
       children: [
         new BlockData({
-          type: "text",
-          title: PreAnnText("Sveditor"),
-          text: PreAnnText(
-            "Below is a nested list of blocks and one day they will be editable!"
-          ),
+          type: "markdown",
+          markdown:
+            "## Sveditor\n\nBelow is a nested list of blocks that are editable!",
         }),
         new BlockData({
-          type: "text",
-          editable: false,
-          text: PreAnnText(
-            "In this example the title and subtitle above are editable, but this piece of content here is not. Below is a container of Story and List blocks."
-          ),
+          type: "markdown",
+          markdown:
+            "Below we have a block in editor mode and then a list of nested blocks",
         }),
-        // new BlockData({
-        //   type: "text",
-        //   editable: true,
-        //   text: PreAnnText(
-        //     "This is an editable text block! And there are multiple lines that I want to render separately.\n Will this actually render the new lines??"
-        //   ),
-        // }),
+        new BlockData({ type: "markdown" }),
         new BlockData({
-          type: "list",
-          editable: false,
-          text: PreAnnText("This is the first sub-list that we get to see:"),
+          type: "markdown",
+          markdown: "This is the first sub-list that we get to see:",
           children: [
             new BlockData({
-              type: "text",
-              editable: true,
-              text: PreAnnText("The first super sub block, what a cool nest!"),
+              type: "markdown",
+              markdown: "The first super sub block, what a cool nest!",
             }),
             new BlockData({
-              type: "text",
-              editable: true,
-              text: PreAnnText("The second super sub block, what a cool nest!"),
+              type: "markdown",
+              markdown: "The second super sub block, what a cool nest!",
             }),
-            // new BlockData({
-            //   type: "text",
-            //   editable: true,
-            //   text: PreAnnText("The last super sub block, what a cool nest!"),
-            // }),
           ],
         }),
         new BlockData({
@@ -69,3 +53,5 @@
 
 <h1 class="text-3xl font-bold tracking-tight">Svedit Editor</h1>
 <Svedit {sveditSession} class="flex flex-col gap-4" />
+<Separator class="h-[4px]" />
+<MarkdocBlock />


### PR DESCRIPTION
Created a "markdown" block type that will render a MarkdownBlock component.

This will either have side by side editor + preview or just have the preview (which looks exactly like just a text block).

Added the relevant icons to the toolbar (which has now been consolidated to the right).

This is in a totally usable state!

**Next Step:** Get DB working!

**Final State**
<img width="1430" alt="Screenshot 2024-12-17 at 2 03 33 AM" src="https://github.com/user-attachments/assets/92de89b0-bfec-4104-8ba6-be98b42e7382" />

